### PR TITLE
Proposed changes to the Roster CSV format.

### DIFF
--- a/patient-roster.md
+++ b/patient-roster.md
@@ -1,4 +1,4 @@
-# Patient Roster Specification Version 1
+# Patient Roster Specification Version 2
 
 ## CSV
 
@@ -107,7 +107,7 @@ Each record in a patient roster file contains the following fields, in the follo
 7. \* [Sex](#sex-format)
 8. \* [Date of birth](#date-format)
 9. [SSN](#ssn-format)
-10. [Phone number](#phone-format)
+10. [Primary Phone number](#phone-format)
 11. Address line 1
 12. Address line 2
 13. City
@@ -132,6 +132,10 @@ Each record in a patient roster file contains the following fields, in the follo
 32. Tag 8
 33. Tag 9
 34. Tag 10
+35. Patient Email
+36. [Cell Phone number](#phone-format)
+37. [Work Phone number](#phone-format)
+38. Medicare Beneficiary Identifier / MBI
 
 Fields marked with (\*) are required to have non-empty values. Other
 fields are allowed to be empty, but non-empty values will be useful


### PR DESCRIPTION
 It is backwards compatible.  No changes will be needed to existing feeds, but adds additional items that may help us improve patient matching going forward.

 - Additional phone numbers for patient.  Right now we collect a single number.  This will allow us to collect home, cell, and work numbers

 - Email.  This the single most useful additional field as emails tend to be extremely unique and are almost never reused.

 - MBI.  Medicare Beneficiary Number.  While our feeds include insurance numbers for multiple private insurers, there is no standardized way to identify an insurer, and we can not assume that an identifier from one insurer does not overlap another.  The only likely unique insurer id we will find is if they are a medicare recipient.  The hospital system knows if the insurance is medicare so this should be a straightforward ask.  In standard HIPAA transactions, Medicare IDs are a separate field from commercial insurance ids.